### PR TITLE
Remove gevent sleep

### DIFF
--- a/feedpuller/feedpuller.py
+++ b/feedpuller/feedpuller.py
@@ -61,8 +61,6 @@ class FeedPuller(object):
                 print ex
                 self.hpc.stop()
                 logger.exception('Exception caught: {0}'.format(ex))
-            #throttle
-            gevent.sleep(5)
 
     def stop(self):
         self.hpc.stop()


### PR DESCRIPTION
Under certain conditions messages were lost because of a race condition between the feedpuller and the hpfeeds socket timeouts.

When a reconnect was forced by feedpuller, the hpfeeds socket would be running the rcv function, so the stop function had no effect on this iteration. This function would then receive an event, save it, and stop. Then feedpuller would sleep for 5 seconds before running hpfeeds once more.

This led to a situation where some attacks that generated multiple events would log only the first event and the subsequent ones would be ignored.