### PR TITLE
Update requirements.txt; Fixes pwnlandia/mhn#863

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ pycrypto==2.6.1
 python-magic==0.4.6
 nose==1.3.4
 kumo==0.2
--e git+https://github.com/threatstream/hpfeeds/#egg=hpfeeds-dev
+-e git+https://github.com/pwnlandia/hpfeeds/#egg=hpfeeds-dev
 Sphinx==1.2.3
 sphinxcontrib-httpdomain==1.3.0


### PR DESCRIPTION
Threatstream repo no longer exists. Closes pwnlandia/mhn#863.

Tested locally with dionea.

Making a PR to point out that hpfeeds is already installed during MHN installation here: https://github.com/pwnlandia/mhn/blob/be58cbf8c726c29c4c0f993023688fdbd026ee05/install.sh#L71C9-L71C9

https://github.com/pwnlandia/mhn/blob/be58cbf8c726c29c4c0f993023688fdbd026ee05/scripts/install_hpfeeds.sh#L61C43-L61C43

Is this redundancy needed?

Additionally, this warning appears during installation of pwnlandia/hpfeeds/#egg=hpfeeds-dev:

```
Obtaining hpfeeds-dev from git+https://github.com/pwnlandia/hpfeeds/#egg=hpfeeds-dev (from -r requirements.txt (line 12))
  Cloning https://github.com/pwnlandia/hpfeeds/ to ./env/src/hpfeeds-dev
  Running command git clone -q https://github.com/pwnlandia/hpfeeds/ /opt/mnemosyne/env/src/hpfeeds-dev
  WARNING: Generating metadata for package hpfeeds-dev produced metadata for project name hpfeeds-threatstream. Fix your #egg=hpfeeds-dev fragments.
```